### PR TITLE
Improve images

### DIFF
--- a/src/components/Hero/Hero.js
+++ b/src/components/Hero/Hero.js
@@ -4,7 +4,30 @@ import styled from 'styled-components/macro';
 const Hero = () => {
   return (
     <Wrapper>
-      <HeroImage src="/images/hero-img.jpg" />
+      <picture>
+        <source
+          type="image/avif"
+          srcSet={
+            `
+              /images/hero-img.avif 1x,
+              /images/hero-img@2x.avif 2x,
+              /images/hero-img@3x.avif 3x
+            `
+          }
+        />
+        <source
+          type="image/jpg"
+          srcSet={
+            `
+              /images/hero-img.jpg 1x,
+              /images/hero-img@2x.jpg 2x,
+              /images/hero-img@3x.jpg 3x
+            `
+          }
+        />
+        <source />
+        <HeroImage src="/images/hero-img.jpg" />
+      </picture>
       <Swoop src="/swoop.svg" />
     </Wrapper>
   );

--- a/src/components/MainContent/MainContent.js
+++ b/src/components/MainContent/MainContent.js
@@ -12,11 +12,12 @@ const MainContent = () => {
       <VisuallyHidden>
         <h1>All Photos</h1>
       </VisuallyHidden>
-      {data.map(({ id, src, alt, tags }) => (
+      {data.map(({ id, src, srcSet, alt, tags }) => (
         <PhotoGridItem
           key={id}
           id={id}
           src={src}
+          srcSet={srcSet}
           alt={alt}
           tags={tags}
         />

--- a/src/components/MainContent/MainContent.js
+++ b/src/components/MainContent/MainContent.js
@@ -12,12 +12,12 @@ const MainContent = () => {
       <VisuallyHidden>
         <h1>All Photos</h1>
       </VisuallyHidden>
-      {data.map(({ id, src, srcSet, alt, tags }) => (
+      {data.map(({ id, src, srcSets, alt, tags }) => (
         <PhotoGridItem
           key={id}
           id={id}
           src={src}
-          srcSet={srcSet}
+          srcSets={srcSets}
           alt={alt}
           tags={tags}
         />

--- a/src/components/PhotoGridItem/PhotoGridItem.js
+++ b/src/components/PhotoGridItem/PhotoGridItem.js
@@ -38,6 +38,7 @@ const Image = styled.img`
   height: 300px;
   border-radius: 2px;
   margin-bottom: 8px;
+  object-fit: cover;
 `;
 
 const Tags = styled.ul`

--- a/src/components/PhotoGridItem/PhotoGridItem.js
+++ b/src/components/PhotoGridItem/PhotoGridItem.js
@@ -5,7 +5,13 @@ const PhotoGridItem = ({ id, src, srcSet, alt, tags }) => {
   return (
     <article>
       <Anchor href={`/photos/${id}`}>
-        <Image src={src} srcSet={srcSet} id={id} />
+        <picture>
+          <source
+            type="image/jpg"
+            srcSet={srcSet}
+          />
+          <Image src={src} id={id} />
+        </picture>
       </Anchor>
       <Tags>
         {tags.map((tag) => (

--- a/src/components/PhotoGridItem/PhotoGridItem.js
+++ b/src/components/PhotoGridItem/PhotoGridItem.js
@@ -7,6 +7,10 @@ const PhotoGridItem = ({ id, src, srcSets, alt, tags }) => {
       <Anchor href={`/photos/${id}`}>
         <picture>
           <source
+            type="image/avif"
+            srcSet={srcSets.avif}
+          />
+          <source
             type="image/jpg"
             srcSet={srcSets.jpg}
           />

--- a/src/components/PhotoGridItem/PhotoGridItem.js
+++ b/src/components/PhotoGridItem/PhotoGridItem.js
@@ -1,14 +1,14 @@
 import React from 'react';
 import styled from 'styled-components/macro';
 
-const PhotoGridItem = ({ id, src, srcSet, alt, tags }) => {
+const PhotoGridItem = ({ id, src, srcSets, alt, tags }) => {
   return (
     <article>
       <Anchor href={`/photos/${id}`}>
         <picture>
           <source
             type="image/jpg"
-            srcSet={srcSet}
+            srcSet={srcSets.jpg}
           />
           <Image src={src} id={id} />
         </picture>

--- a/src/components/PhotoGridItem/PhotoGridItem.js
+++ b/src/components/PhotoGridItem/PhotoGridItem.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import styled from 'styled-components/macro';
 
-const PhotoGridItem = ({ id, src, alt, tags }) => {
+const PhotoGridItem = ({ id, src, srcSet, alt, tags }) => {
   return (
     <article>
       <Anchor href={`/photos/${id}`}>
-        <Image src={src} />
+        <Image src={src} srcSet={srcSet} id={id} />
       </Anchor>
       <Tags>
         {tags.map((tag) => (

--- a/src/data.js
+++ b/src/data.js
@@ -2,11 +2,13 @@ const data = [
   {
     id: 'a',
     src: '/images/vincent-van-zalinge-bird.jpg',
-    srcSet: `
-      /images/vincent-van-zalinge-bird.jpg 1x,
-      /images/vincent-van-zalinge-bird@2x.jpg 2x,
-      /images/vincent-van-zalinge-bird@3x.jpg 3x
-    `,
+    srcSets: {
+      jpg: `
+        /images/vincent-van-zalinge-bird.jpg 1x,
+        /images/vincent-van-zalinge-bird@2x.jpg 2x,
+        /images/vincent-van-zalinge-bird@3x.jpg 3x
+      `
+    },
     alt: 'A tiny shrewd turquoise-and-amber bird',
     tags: [
       'bird',
@@ -18,66 +20,78 @@ const data = [
   {
     id: 'b',
     src: '/images/alexandru-rotariu-dog.jpg',
-    srcSet: `
-      /images/alexandru-rotariu-dog.jpg 1x,
-      /images/alexandru-rotariu-dog@2x.jpg 2x,
-      /images/alexandru-rotariu-dog@3x.jpg 3x
-    `,
+    srcSets: {
+      jpg: `
+        /images/alexandru-rotariu-dog.jpg 1x,
+        /images/alexandru-rotariu-dog@2x.jpg 2x,
+        /images/alexandru-rotariu-dog@3x.jpg 3x
+      `
+    },
     alt: 'A serious-looking grey dog with cool glacier eyes',
     tags: ['dog', 'HD'],
   },
   {
     id: 'c',
     src: '/images/scott-walsh-fox.jpg',
-    srcSet: `
-      /images/scott-walsh-fox.jpg 1x,
-      /images/scott-walsh-fox@2x.jpg 2x,
-      /images/scott-walsh-fox@3x.jpg 3x 
-    `,
+    srcSets: {
+      jpg: `
+        /images/scott-walsh-fox.jpg 1x,
+        /images/scott-walsh-fox@2x.jpg 2x,
+        /images/scott-walsh-fox@3x.jpg 3x 
+      `
+    },
     alt: 'A happy-looking cute wild fox in nature, near some pink flowers',
     tags: ['fox', 'flowers'],
   },
   {
     id: 'd',
     src: '/images/andy-holmes-giraffe.jpg',
-    srcSet: `
-      /images/andy-holmes-giraffe.jpg 1x,
-      /images/andy-holmes-giraffe@2x.jpg 2x,
-      /images/andy-holmes-giraffe@3x.jpg 3x
-    `,
+    srcSets: {
+      jpg: `
+        /images/andy-holmes-giraffe.jpg 1x,
+        /images/andy-holmes-giraffe@2x.jpg 2x,
+        /images/andy-holmes-giraffe@3x.jpg 3x
+      `
+    },
     alt: 'A giraffe sticking its black tongue out',
     tags: ['giraffe', 'dramatic'],
   },
   {
     id: 'e',
     src: '/images/karsten-winegeart-dog.jpg',
-    srcSet: `
-      /images/karsten-winegeart-dog.jpg 1x, 
-      /images/karsten-winegeart-dog@2x.jpg 2x,
-      /images/karsten-winegeart-dog@3x.jpg 3x
-    `,
+    srcSets: {
+      jpg: `
+        /images/karsten-winegeart-dog.jpg 1x, 
+        /images/karsten-winegeart-dog@2x.jpg 2x,
+        /images/karsten-winegeart-dog@3x.jpg 3x
+      `
+    },
     alt: 'A small dog wearing a golden "Champions" hoodie',
     tags: ['dog', 'cute', 'animal wearing human clothes'],
   },
   {
     id: 'f',
     src: '/images/marko-blazevic-cat.jpg',
-    srcSet: `
-      /images/marko-blazevic-cat.jpg 1x,
-      /images/marko-blazevic-cat@2x.jpg 2x,
-      /images/marko-blazevic-cat@3x.jpg 3x
-    `,
+    srcSets: {
+      jpg: `
+        /images/marko-blazevic-cat.jpg 1x,
+        /images/marko-blazevic-cat@2x.jpg 2x,
+        /images/marko-blazevic-cat@3x.jpg 3x
+      `
+    },
     alt: 'A small kitten standing on its back legs, reaching up towards the camera',
     tags: ['kitten', 'cat', '#cute'],
   },
   {
     id: 'g',
     src: '/images/mark-stoop-lizard.jpg',
-    srcSet: `
-      /images/mark-stoop-lizard.jpg 1x,
-      /images/mark-stoop-lizard@2x.jpg 2x,
-      /images/mark-stoop-lizard@3x.jpg 3x
-    `,
+    srcSets: {
+      jpg: `
+        /images/mark-stoop-lizard.jpg 1x,
+        /images/mark-stoop-lizard@2x.jpg 2x,
+        /images/mark-stoop-lizard@3x.jpg 3x
+      `
+    },
     alt: 'A relaxed green lizard, sitting on a wooden beam',
     tags: [
       'lizard',
@@ -87,22 +101,26 @@ const data = [
   {
     id: 'h',
     src: '/images/geran-de-klerk-squirrel.jpg',
-    srcSet: `
-      /images/geran-de-klerk-squirrel.jpg 1x,
-      /images/geran-de-klerk-squirrel@2x.jpg 2x,
-      /images/geran-de-klerk-squirrel@3x.jpg 3x
-    `,
+    srcSets: {
+      jpg: `
+        /images/geran-de-klerk-squirrel.jpg 1x,
+        /images/geran-de-klerk-squirrel@2x.jpg 2x,
+        /images/geran-de-klerk-squirrel@3x.jpg 3x
+      `
+    },
     alt: 'A fuzzy squirrel, highlighted in a dark backdrop',
     tags: ['squirrel', 'animal', 'fuzzy'],
   },
   {
     id: 'i',
     src: '/images/wexor-tmg-turtle.jpg',
-    srcSet: `
-      /images/wexor-tmg-turtle.jpg 1,
-      /images/wexor-tmg-turtle@2x.jpg 2x,
-      /images/wexor-tmg-turtle@3x.jpg 3x
-    `,
+    srcSets: {
+      jpg: `
+        /images/wexor-tmg-turtle.jpg 1,
+        /images/wexor-tmg-turtle@2x.jpg 2x,
+        /images/wexor-tmg-turtle@3x.jpg 3x
+      `
+    },
     alt: 'A large tropical turtle swimming in water',
     tags: ['turtle', 'ocean', 'flippers'],
   },

--- a/src/data.js
+++ b/src/data.js
@@ -7,7 +7,12 @@ const data = [
         /images/vincent-van-zalinge-bird.jpg 1x,
         /images/vincent-van-zalinge-bird@2x.jpg 2x,
         /images/vincent-van-zalinge-bird@3x.jpg 3x
-      `
+      `,
+      avif: `
+        /images/vincent-van-zalinge-bird.avif 1x,
+        /images/vincent-van-zalinge-bird@2x.avif 2x,
+        /images/vincent-van-zalinge-bird@3x.avif 3x
+      `,
     },
     alt: 'A tiny shrewd turquoise-and-amber bird',
     tags: [
@@ -25,7 +30,12 @@ const data = [
         /images/alexandru-rotariu-dog.jpg 1x,
         /images/alexandru-rotariu-dog@2x.jpg 2x,
         /images/alexandru-rotariu-dog@3x.jpg 3x
-      `
+      `,
+      avif: `
+        /images/alexandru-rotariu-dog.avif 1x,
+        /images/alexandru-rotariu-dog@2x.avif 2x,
+        /images/alexandru-rotariu-dog@3x.avif 3x
+      `,
     },
     alt: 'A serious-looking grey dog with cool glacier eyes',
     tags: ['dog', 'HD'],
@@ -38,7 +48,12 @@ const data = [
         /images/scott-walsh-fox.jpg 1x,
         /images/scott-walsh-fox@2x.jpg 2x,
         /images/scott-walsh-fox@3x.jpg 3x 
-      `
+      `,
+      avif: `
+        /images/scott-walsh-fox.avif 1x,
+        /images/scott-walsh-fox@2x.avif 2x,
+        /images/scott-walsh-fox@3x.avif 3x
+      `,
     },
     alt: 'A happy-looking cute wild fox in nature, near some pink flowers',
     tags: ['fox', 'flowers'],
@@ -51,7 +66,12 @@ const data = [
         /images/andy-holmes-giraffe.jpg 1x,
         /images/andy-holmes-giraffe@2x.jpg 2x,
         /images/andy-holmes-giraffe@3x.jpg 3x
-      `
+      `,
+      avifjpg: `
+        /images/andy-holmes-giraffe.avif 1x,
+        /images/andy-holmes-giraffe@2x.avif 2x,
+        /images/andy-holmes-giraffe@3x.avif 3x
+      `,
     },
     alt: 'A giraffe sticking its black tongue out',
     tags: ['giraffe', 'dramatic'],
@@ -64,7 +84,12 @@ const data = [
         /images/karsten-winegeart-dog.jpg 1x, 
         /images/karsten-winegeart-dog@2x.jpg 2x,
         /images/karsten-winegeart-dog@3x.jpg 3x
-      `
+      `,
+      avif: `
+        /images/karsten-winegeart-dog.avif 1x,
+        /images/karsten-winegeart-dog@2x.avif 2x,
+        /images/karsten-winegeart-dog@3x.avif 3x
+      `,
     },
     alt: 'A small dog wearing a golden "Champions" hoodie',
     tags: ['dog', 'cute', 'animal wearing human clothes'],
@@ -77,7 +102,12 @@ const data = [
         /images/marko-blazevic-cat.jpg 1x,
         /images/marko-blazevic-cat@2x.jpg 2x,
         /images/marko-blazevic-cat@3x.jpg 3x
-      `
+      `,
+      avif: `
+        /images/marko-blazevic-cat.avif 1x,
+        /images/marko-blazevic-cat@2x.avif 2x,
+        /images/marko-blazevic-cat@3x.javif 3x
+      `,
     },
     alt: 'A small kitten standing on its back legs, reaching up towards the camera',
     tags: ['kitten', 'cat', '#cute'],
@@ -90,6 +120,11 @@ const data = [
         /images/mark-stoop-lizard.jpg 1x,
         /images/mark-stoop-lizard@2x.jpg 2x,
         /images/mark-stoop-lizard@3x.jpg 3x
+      `,
+      avif: `
+        /images/mark-stoop-lizard.avif 1x,
+        /images/mark-stoop-lizard@2x.avif 2x,
+        /images/mark-stoop-lizard@3x.avif 3x
       `
     },
     alt: 'A relaxed green lizard, sitting on a wooden beam',
@@ -106,7 +141,12 @@ const data = [
         /images/geran-de-klerk-squirrel.jpg 1x,
         /images/geran-de-klerk-squirrel@2x.jpg 2x,
         /images/geran-de-klerk-squirrel@3x.jpg 3x
-      `
+      `,
+      avif: `
+        /images/geran-de-klerk-squirrel.avif 1x,
+        /images/geran-de-klerk-squirrel@2x.avif 2x,
+        /images/geran-de-klerk-squirrel@3x.avif 3x
+      `,
     },
     alt: 'A fuzzy squirrel, highlighted in a dark backdrop',
     tags: ['squirrel', 'animal', 'fuzzy'],
@@ -119,7 +159,12 @@ const data = [
         /images/wexor-tmg-turtle.jpg 1,
         /images/wexor-tmg-turtle@2x.jpg 2x,
         /images/wexor-tmg-turtle@3x.jpg 3x
-      `
+      `,
+      avif: `
+        /images/wexor-tmg-turtle.avif 1,
+        /images/wexor-tmg-turtle@2x.avif 2x,
+        /images/wexor-tmg-turtle@3x.avif 3x
+      `,
     },
     alt: 'A large tropical turtle swimming in water',
     tags: ['turtle', 'ocean', 'flippers'],

--- a/src/data.js
+++ b/src/data.js
@@ -2,6 +2,11 @@ const data = [
   {
     id: 'a',
     src: '/images/vincent-van-zalinge-bird.jpg',
+    srcSet: `
+      /images/vincent-van-zalinge-bird.jpg 1x,
+      /images/vincent-van-zalinge-bird@2x.jpg 2x,
+      /images/vincent-van-zalinge-bird@3x.jpg 3x
+    `,
     alt: 'A tiny shrewd turquoise-and-amber bird',
     tags: [
       'bird',
@@ -13,36 +18,66 @@ const data = [
   {
     id: 'b',
     src: '/images/alexandru-rotariu-dog.jpg',
+    srcSet: `
+      /images/alexandru-rotariu-dog.jpg 1x,
+      /images/alexandru-rotariu-dog@2x.jpg 2x,
+      /images/alexandru-rotariu-dog@3x.jpg 3x
+    `,
     alt: 'A serious-looking grey dog with cool glacier eyes',
     tags: ['dog', 'HD'],
   },
   {
     id: 'c',
     src: '/images/scott-walsh-fox.jpg',
+    srcSet: `
+      /images/scott-walsh-fox.jpg 1x,
+      /images/scott-walsh-fox@2x.jpg 2x,
+      /images/scott-walsh-fox@3x.jpg 3x 
+    `,
     alt: 'A happy-looking cute wild fox in nature, near some pink flowers',
     tags: ['fox', 'flowers'],
   },
   {
     id: 'd',
     src: '/images/andy-holmes-giraffe.jpg',
+    srcSet: `
+      /images/andy-holmes-giraffe.jpg 1x,
+      /images/andy-holmes-giraffe@2x.jpg 2x,
+      /images/andy-holmes-giraffe@3x.jpg 3x
+    `,
     alt: 'A giraffe sticking its black tongue out',
     tags: ['giraffe', 'dramatic'],
   },
   {
     id: 'e',
     src: '/images/karsten-winegeart-dog.jpg',
+    srcSet: `
+      /images/karsten-winegeart-dog.jpg 1x, 
+      /images/karsten-winegeart-dog@2x.jpg 2x,
+      /images/karsten-winegeart-dog@3x.jpg 3x
+    `,
     alt: 'A small dog wearing a golden "Champions" hoodie',
     tags: ['dog', 'cute', 'animal wearing human clothes'],
   },
   {
     id: 'f',
     src: '/images/marko-blazevic-cat.jpg',
+    srcSet: `
+      /images/marko-blazevic-cat.jpg 1x,
+      /images/marko-blazevic-cat@2x.jpg 2x,
+      /images/marko-blazevic-cat@3x.jpg 3x
+    `,
     alt: 'A small kitten standing on its back legs, reaching up towards the camera',
     tags: ['kitten', 'cat', '#cute'],
   },
   {
     id: 'g',
     src: '/images/mark-stoop-lizard.jpg',
+    srcSet: `
+      /images/mark-stoop-lizard.jpg 1x,
+      /images/mark-stoop-lizard@2x.jpg 2x,
+      /images/mark-stoop-lizard@3x.jpg 3x
+    `,
     alt: 'A relaxed green lizard, sitting on a wooden beam',
     tags: [
       'lizard',
@@ -52,12 +87,22 @@ const data = [
   {
     id: 'h',
     src: '/images/geran-de-klerk-squirrel.jpg',
+    srcSet: `
+      /images/geran-de-klerk-squirrel.jpg 1x,
+      /images/geran-de-klerk-squirrel@2x.jpg 2x,
+      /images/geran-de-klerk-squirrel@3x.jpg 3x
+    `,
     alt: 'A fuzzy squirrel, highlighted in a dark backdrop',
     tags: ['squirrel', 'animal', 'fuzzy'],
   },
   {
     id: 'i',
     src: '/images/wexor-tmg-turtle.jpg',
+    srcSet: `
+      /images/wexor-tmg-turtle.jpg 1,
+      /images/wexor-tmg-turtle@2z.jpg 2x,
+      /images/wexor-tmg-turtle@3x.jpg 3x
+    `,
     alt: 'A large tropical turtle swimming in water',
     tags: ['turtle', 'ocean', 'flippers'],
   },

--- a/src/data.js
+++ b/src/data.js
@@ -100,7 +100,7 @@ const data = [
     src: '/images/wexor-tmg-turtle.jpg',
     srcSet: `
       /images/wexor-tmg-turtle.jpg 1,
-      /images/wexor-tmg-turtle@2z.jpg 2x,
+      /images/wexor-tmg-turtle@2x.jpg 2x,
       /images/wexor-tmg-turtle@3x.jpg 3x
     `,
     alt: 'A large tropical turtle swimming in water',


### PR DESCRIPTION
Submission for [exercise 2](https://github.com/VrsajkovIvan33/unsprinkle?tab=readme-ov-file#exercise-2-improve-images).

- Add responsivennes to image sources based on DPI with `srcset`.
- Add support for `.avif` images.
- Restore aspect ratio for images in the grid.